### PR TITLE
Сетка на флексах для главной страницы

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -138,9 +138,12 @@
 
       <ul class="hotels-list">
         <li class="hotels-item">
-          <a class="hotel-link" href="#">
-            <h2 class="hotel-name">Amara Resort &amp; Spa</h2>
-          </a>
+          <div class="hotel-link">
+            <a href="#">
+              <h2 class="hotel-name">Amara Resort &amp; Spa</h2>
+            </a>
+
+          </div>
           <img src="img/hotels/amara.jpg" class="hotel-image" alt="Гостиница Amara Resort &amp; Spa" width="135" height="90">
           <p class="hotel-type">Гостиница</p>
           <p class="hotel-price">От 4000 Р.</p>
@@ -163,9 +166,11 @@
           <button type="button" class="btn btn-order btn-brown">Забронировать</button>
         </li>
         <li class="hotels-item">
-          <a class="hotel-link" href="#">
-            <h2 class="hotel-name">Desert Quail Inn</h2>
-          </a>
+          <div class="hotel-link">
+            <a href="#">
+              <h2 class="hotel-name">Desert Quail Inn</h2>
+            </a>
+          </div>
           <img src="img/hotels/desertquall.jpg" class="hotel-image" alt="Мотель Desert Quail Inn" width="135" height="90">
           <p class="hotel-type">Мотель</p>
           <p class="hotel-price">От 3000 Р.</p>
@@ -185,9 +190,11 @@
           <button type="button" class="btn btn-order btn-brown">Забронировать</button>
         </li>
         <li class="hotels-item">
-          <a class="hotel-link" href="#">
-            <h2 class="hotel-name">Villas at Poco Diablo</h2>
-          </a>
+          <div class="hotel-link">
+            <a href="#">
+              <h2 class="hotel-name">Villas at Poco Diablo</h2>
+            </a>
+          </div>
           <img src="img/hotels/villasatpoco.jpg" class="hotel-image" alt="Апартаменты Villas at Poco Diablo" width="135" height="90">
           <p class="hotel-type">Апартаменты</p>
           <p class="hotel-price">От 2000 Р.</p>

--- a/css/style.css
+++ b/css/style.css
@@ -81,6 +81,12 @@ button {
   width: 1px;
   height: 1px;
   margin: -1px;
+  border: 0;
+  padding: 0;
+  white-space: nowrap;
+  clip-path: inset(100%);
+  clip: rect(0 0 0 0);
+  overflow: hidden;
 }
 
 /* Interactive elements*/
@@ -415,7 +421,7 @@ button {
   line-height: 26px;
   font-weight: 700;
   margin: 0;
-  margin-left: 29px
+  margin-bottom: 7px;
 }
 
 fieldset {
@@ -463,11 +469,17 @@ fieldset legend {
 }
 
 .hotel-type,
+.hotel-price,
+.hotel-stars {
+  margin: 0;
+}
+
+.hotel-type,
 .hotel-price {
   font-size: 14px;
   line-height: 21px;
   color: var(--extra-black);
-  margin: 0;
+  margin-bottom: 15px;
 }
 
 .hotel-rating {
@@ -565,13 +577,20 @@ fieldset legend {
   grid-column: 1/-1;
 }
 
-.search-form input[type="number"] {
-  width: 37px;
-  text-align: center;
-}
 
 .search-form input[type="text"] {
-  width: 308px;
+  padding: 6px;
+  padding-left: 13px;
+  width: 346px;
+}
+
+.number input[type="text"] {
+  padding: 6px 0;
+  width: 37px;
+}
+
+.number ::placeholder {
+  text-align: center;
 }
 
 /* Catalog page grid layout*/
@@ -582,33 +601,33 @@ fieldset legend {
 }
 
 .hotels-item {
-  padding: 30px 73px;
-  padding-right: 71px;
+  padding: 23px 71px 30px 73px;
   border-top: solid 1px var(--focus-gray);
   display: grid;
-  grid-template-columns: 135px 139px 148px 1fr 110px;
+  grid-template-columns: 135px 29px 110px 6px 142px 1fr 110px;
   grid-template-rows: min-content min-content 27px;
 }
 
 .hotel-link {
-  grid-column: 2/-2;
+  grid-column: 3/-2;
+  /*margin-left: 29px;*/
+  display: flex;
 }
 
 .hotel-image {
   grid-row: 1/4;
   grid-column: 1/2;
+  margin-top: 6px;
 }
 
 .hotel-type {
   grid-row: 2/3;
-  grid-column: 2/3;
-  margin-left: 29px;
+  grid-column: 3/4;
 }
 
 .hotel-price {
   grid-row: 2/3;
-  grid-column: 3/4;
-  margin-left: 6px;
+  grid-column: 5/6;
 }
 
 .hotel-stars {
@@ -625,18 +644,16 @@ fieldset legend {
 
 .btn-info {
   grid-row: 3/4;
-  grid-column: 2/3;
-  margin-left: 29px;
+  grid-column: 3/4;
 }
 
 .btn-order {
   grid-row: 3/4;
-  grid-column: 3/4;
-  margin-left: 6px;
+  grid-column: 5/6;
 }
 
 /* Layout Flex Main Page*/
-/*
+
 .feature-item div {
   display: flex;
   justify-content: center;
@@ -709,11 +726,13 @@ fieldset legend {
   display: flex;
   flex-direction: column;
 }
-*/
+
 /* Margins and Paddings*/
-/*
+
 .promo h2 {
-  padding: 20px 365px;
+  padding: 43px 365px;
+  padding-bottom: 30px;
+  margin: 0;
 }
 
 .promo p {
@@ -775,12 +794,6 @@ fieldset legend {
 
 .footer-right p {
   margin-right: 8px;
-}
-
-.search-form input[type="text"] {
-  padding: 6px;
-  padding-left: 13px;
-  width: 346px;
 }
 
 .search-form {
@@ -847,6 +860,8 @@ fieldset legend {
 
 .hotels-header p {
   align-self: center;
+  margin: 0;
+  margin-top: 4px;
 }
 
 /* Header Logo */
@@ -858,4 +873,3 @@ fieldset legend {
   transform: translateX(-50%);
   max-width: 138px;
 }
-*/

--- a/index.html
+++ b/index.html
@@ -185,68 +185,68 @@
     <h2 class="visually-hidden">Поиск гостиницы в Седоне</h2>
     <form action="https://echo.htmlacademy.ru" method="POST">
 
-        <label for="start-date" class="start-date">Дата заезда:</label>
-        <div class="search-form-input-group">
-          <input type="text" placeholder="24 апреля 2017" id="start-date" name="start-date">
-          <button type="button" class="btn-control">
-            <svg class="btn-calendar calend-arrival" width="21" height="23" fill="none"
-              xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" clip-rule="evenodd"
-                d="M16.4 3.02h2.85c.97 0 1.75.83 1.75 1.84v16.3A1.8 1.8 0 0119.25 23H1.75A1.8 1.8 0 010 21.16V4.86a1.8 1.8 0 011.75-1.84h2.84V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37zm3.16 18.46c.09-.08.13-.2.13-.32V4.86c0-.25-.2-.46-.44-.46h-2.84v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4h-3.94v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4H5.9v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.66-.69V4.4H1.75a.45.45 0 00-.44.46v16.3c0 .25.2.46.44.46h17.5c.12 0 .23-.05.31-.14z" />
-              <path fill-rule="evenodd" clip-rule="evenodd"
-                d="M4.6 9.23h2.62v2.06H4.59V9.23zm0 3.44h2.62v2.07H4.59v-2.07zm2.62 3.44H4.59v2.07h2.63V16.1zm1.97 0h2.62v2.07H9.2V16.1zm2.62-3.44H9.2v2.07h2.62v-2.07zM9.2 9.23h2.62v2.06H9.2V9.23zm7.22 6.88h-2.63v2.07h2.63V16.1zm-2.63-3.44h2.63v2.07h-2.63v-2.07zm2.63-3.44h-2.63v2.06h2.63V9.23z" />
-            </svg>
-          </button>
-        </div>
-
-
-        <label for="end-date" class="end-date">Дата выезда:</label>
-        <div class="search-form-input-group">
-          <input type="text" placeholder="4 июля 2017" id="end-date" name="end-date">
-          <button type="button" class="btn-control">
-            <svg class="btn-calendar calend-departure" width="21" height="23" fill="none"
-              xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" clip-rule="evenodd"
-                d="M16.4 3.02h2.85c.97 0 1.75.83 1.75 1.84v16.3A1.8 1.8 0 0119.25 23H1.75A1.8 1.8 0 010 21.16V4.86a1.8 1.8 0 011.75-1.84h2.84V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37zm3.16 18.46c.09-.08.13-.2.13-.32V4.86c0-.25-.2-.46-.44-.46h-2.84v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4h-3.94v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4H5.9v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.66-.69V4.4H1.75a.45.45 0 00-.44.46v16.3c0 .25.2.46.44.46h17.5c.12 0 .23-.05.31-.14z" />
-              <path fill-rule="evenodd" clip-rule="evenodd"
-                d="M4.6 9.23h2.62v2.06H4.59V9.23zm0 3.44h2.62v2.07H4.59v-2.07zm2.62 3.44H4.59v2.07h2.63V16.1zm1.97 0h2.62v2.07H9.2V16.1zm2.62-3.44H9.2v2.07h2.62v-2.07zM9.2 9.23h2.62v2.06H9.2V9.23zm7.22 6.88h-2.63v2.07h2.63V16.1zm-2.63-3.44h2.63v2.07h-2.63v-2.07zm2.63-3.44h-2.63v2.06h2.63V9.23z" />
-            </svg>
-          </button>
-        </div>
-
-
-        <label for="adults" class="adults">Взрослые:</label>
-        <div class="search-form-input-group">
-          <button type="button" class="btn-control">
-            <svg class="btn-count btn-minus" width="12" height="3" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M0 0h12v3H0z" />
-            </svg>
-          </button>
-          <input type="number" id="adults" name="adults" placeholder="2">
-          <button type="button" class="btn-control">
-            <svg class="btn-count btn-plus" width="11" height="11" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" clip-rule="evenodd"
-                d="M4.23 6.77V11h2.54V6.77H11V4.23H6.77V0H4.23v4.23H0v2.54h4.23z" />
-            </svg>
-        </div>
-
+      <label for="start-date" class="start-date">Дата заезда:</label>
+      <div class="search-form-input-group">
+        <input type="text" placeholder="24 апреля 2017" id="start-date" name="start-date">
+        <button type="button" class="btn-control">
+          <svg class="btn-calendar calend-arrival" width="21" height="23" fill="none"
+            xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M16.4 3.02h2.85c.97 0 1.75.83 1.75 1.84v16.3A1.8 1.8 0 0119.25 23H1.75A1.8 1.8 0 010 21.16V4.86a1.8 1.8 0 011.75-1.84h2.84V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37zm3.16 18.46c.09-.08.13-.2.13-.32V4.86c0-.25-.2-.46-.44-.46h-2.84v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4h-3.94v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4H5.9v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.66-.69V4.4H1.75a.45.45 0 00-.44.46v16.3c0 .25.2.46.44.46h17.5c.12 0 .23-.05.31-.14z" />
+            <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M4.6 9.23h2.62v2.06H4.59V9.23zm0 3.44h2.62v2.07H4.59v-2.07zm2.62 3.44H4.59v2.07h2.63V16.1zm1.97 0h2.62v2.07H9.2V16.1zm2.62-3.44H9.2v2.07h2.62v-2.07zM9.2 9.23h2.62v2.06H9.2V9.23zm7.22 6.88h-2.63v2.07h2.63V16.1zm-2.63-3.44h2.63v2.07h-2.63v-2.07zm2.63-3.44h-2.63v2.06h2.63V9.23z" />
+          </svg>
         </button>
+      </div>
 
-        <label for="childrens" class="childrens">Дети:</label>
-        <div class="search-form-input-group">
-          <button type="button" class="btn-control">
-            <svg class="btn-count btn-minus" width="12" height="3" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M0 0h12v3H0z" />
-            </svg>
-          </button>
-          <input type="number" id="childrens" name="childrens" placeholder="2">
-          <button type="button" class="btn-control">
-            <svg class="btn-count btn-plus" width="11" height="11" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" clip-rule="evenodd"
-                d="M4.23 6.77V11h2.54V6.77H11V4.23H6.77V0H4.23v4.23H0v2.54h4.23z" />
-            </svg>
-          </button>
-        </div>
+
+      <label for="end-date" class="end-date">Дата выезда:</label>
+      <div class="search-form-input-group">
+        <input type="text" placeholder="4 июля 2017" id="end-date" name="end-date">
+        <button type="button" class="btn-control">
+          <svg class="btn-calendar calend-departure" width="21" height="23" fill="none"
+            xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M16.4 3.02h2.85c.97 0 1.75.83 1.75 1.84v16.3A1.8 1.8 0 0119.25 23H1.75A1.8 1.8 0 010 21.16V4.86a1.8 1.8 0 011.75-1.84h2.84V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37h3.93V1.65c0-.38.3-.7.66-.7.36 0 .66.32.66.7v1.37zm3.16 18.46c.09-.08.13-.2.13-.32V4.86c0-.25-.2-.46-.44-.46h-2.84v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4h-3.94v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.65-.69V4.4H5.9v1.38c0 .38-.3.69-.66.69a.67.67 0 01-.66-.69V4.4H1.75a.45.45 0 00-.44.46v16.3c0 .25.2.46.44.46h17.5c.12 0 .23-.05.31-.14z" />
+            <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M4.6 9.23h2.62v2.06H4.59V9.23zm0 3.44h2.62v2.07H4.59v-2.07zm2.62 3.44H4.59v2.07h2.63V16.1zm1.97 0h2.62v2.07H9.2V16.1zm2.62-3.44H9.2v2.07h2.62v-2.07zM9.2 9.23h2.62v2.06H9.2V9.23zm7.22 6.88h-2.63v2.07h2.63V16.1zm-2.63-3.44h2.63v2.07h-2.63v-2.07zm2.63-3.44h-2.63v2.06h2.63V9.23z" />
+          </svg>
+        </button>
+      </div>
+
+
+      <label for="adults" class="adults">Взрослые:</label>
+      <div class="search-form-input-group number">
+        <button type="button" class="btn-control">
+          <svg class="btn-count btn-minus" width="12" height="3" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 0h12v3H0z" />
+          </svg>
+        </button>
+        <input type="text" id="adults" name="adults" placeholder="2">
+        <button type="button" class="btn-control">
+          <svg class="btn-count btn-plus" width="11" height="11" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M4.23 6.77V11h2.54V6.77H11V4.23H6.77V0H4.23v4.23H0v2.54h4.23z" />
+          </svg>
+      </div>
+
+      </button>
+
+      <label for="childrens" class="childrens">Дети:</label>
+      <div class="search-form-input-group number">
+        <button type="button" class="btn-control">
+          <svg class="btn-count btn-minus" width="12" height="3" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 0h12v3H0z" />
+          </svg>
+        </button>
+        <input type="text" id="childrens" name="childrens" placeholder="2">
+        <button type="button" class="btn-control">
+          <svg class="btn-count btn-plus" width="11" height="11" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M4.23 6.77V11h2.54V6.77H11V4.23H6.77V0H4.23v4.23H0v2.54h4.23z" />
+          </svg>
+        </button>
+      </div>
 
 
 


### PR DESCRIPTION
1. FIX: Мелкие правки формы главной страницы - типы полей text вместо number, чтобы placeholder был по центру
2. FIX: Исправлены отступы h2 секции promo главной страницы
3. FIX: Исправлена грид-сетка списка отелей, вместо gap использованы пустые грид-колонки (разной ширины), чтобы не использовать margin
4. FIX: Ссылка hotel-link обернута в div, чтобы ее не растягивало на всю ширину грид-контейнера (появляются пустые места на которые можно случайно нажать). Возможно, можно сделать проще.
5. Сетка на флексах для главной страницы
6. Отступы

---
:mortar_board: [Сетка на флексах для главной страницы](https://up.htmlacademy.ru/htmlcss/30/user/1282227/tasks/9)

:boom: https://htmlacademy-htmlcss.github.io/1282227-sedona-30/9/